### PR TITLE
Use ConcurrentDictionary

### DIFF
--- a/src/Colorful.Console.Tests/ColorStoreTests.cs
+++ b/src/Colorful.Console.Tests/ColorStoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -17,7 +18,7 @@ namespace Colorful.Console.Tests
 
         public static ColorStore GetColorStore()
         {
-            ColorStore colorStore = new ColorStore(new Dictionary<Color, ConsoleColor>(), new Dictionary<ConsoleColor, Color>());
+            ColorStore colorStore = new ColorStore(new ConcurrentDictionary<Color, ConsoleColor>(), new ConcurrentDictionary<ConsoleColor, Color>());
             colorStore.Update(TEST_COLOR, TEST_CONSOLE_COLOR);
 
             return colorStore;

--- a/src/Colorful.Console/ColorManagerFactory.cs
+++ b/src/Colorful.Console/ColorManagerFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -18,7 +19,7 @@ namespace Colorful
             return new ColorManager(colorStore, GetColorMapper(), maxColorChanges, initialColorChangeCountValue);
         }
 
-        public ColorManager GetManager(Dictionary<Color, ConsoleColor> colorMap, Dictionary<ConsoleColor, Color> consoleColorMap, int maxColorChanges, int initialColorChangeCountValue)
+        public ColorManager GetManager(ConcurrentDictionary<Color, ConsoleColor> colorMap, ConcurrentDictionary<ConsoleColor, Color> consoleColorMap, int maxColorChanges, int initialColorChangeCountValue)
         {
             ColorStore colorStore = GetColorStore(colorMap, consoleColorMap);
             ColorMapper colorMapper = GetColorMapper();
@@ -26,7 +27,7 @@ namespace Colorful
             return new ColorManager(colorStore, colorMapper, maxColorChanges, initialColorChangeCountValue);
         }
 
-        private ColorStore GetColorStore(Dictionary<Color, ConsoleColor> colorMap, Dictionary<ConsoleColor, Color> consoleColorMap)
+        private ColorStore GetColorStore(ConcurrentDictionary<Color, ConsoleColor> colorMap, ConcurrentDictionary<ConsoleColor, Color> consoleColorMap)
         {
             return new ColorStore(colorMap, consoleColorMap);
         }

--- a/src/Colorful.Console/ColorStore.cs
+++ b/src/Colorful.Console/ColorStore.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,11 +16,11 @@ namespace Colorful
         /// <summary>
         /// A map from System.Drawing.Color to ConsoleColor.
         /// </summary>
-        public Dictionary<Color, ConsoleColor> Colors { get; private set; }
+        public ConcurrentDictionary<Color, ConsoleColor> Colors { get; private set; }
         /// <summary>
         /// A map from ConsoleColor to System.Drawing.Color.
         /// </summary>
-        public Dictionary<ConsoleColor, Color> ConsoleColors { get; private set; }
+        public ConcurrentDictionary<ConsoleColor, Color> ConsoleColors { get; private set; }
 
         /// <summary>
         /// Manages the assignment of System.Drawing.Color objects to ConsoleColor objects.
@@ -28,7 +29,7 @@ namespace Colorful
         /// to ConsoleColor objects.</param>
         /// <param name="consoleColorMap">The Dictionary the ColorStore should use to key ConsoleColor
         /// objects to System.Drawing.Color objects.</param>
-        public ColorStore(Dictionary<Color, ConsoleColor> colorMap, Dictionary<ConsoleColor, Color> consoleColorMap)
+        public ColorStore(ConcurrentDictionary<Color, ConsoleColor> colorMap, ConcurrentDictionary<ConsoleColor, Color> consoleColorMap)
         {
             Colors = colorMap;
             ConsoleColors = consoleColorMap;
@@ -41,7 +42,7 @@ namespace Colorful
         /// <param name="oldColor">The ConsoleColor to be replaced by the new System.Drawing.Color.</param>
         public void Update(Color newColor, ConsoleColor oldColor)
         {
-            Colors.Add(newColor, oldColor);
+            Colors.TryAdd(newColor, oldColor);
             ConsoleColors[oldColor] = newColor;
         }
 

--- a/src/Colorful.Console/ColorfulConsoleBack.cs
+++ b/src/Colorful.Console/ColorfulConsoleBack.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -262,26 +263,25 @@ namespace Colorful
 
         private static ColorStore GetColorStore()
         {
-            Dictionary<Color, ConsoleColor> colorMap = new Dictionary<Color, ConsoleColor>();
-            Dictionary<ConsoleColor, Color> consoleColorMap = new Dictionary<ConsoleColor, Color>
-            {
-                {ConsoleColor.Black, blackEquivalent},
-                {ConsoleColor.Blue, blueEquivalent},
-                {ConsoleColor.Cyan, cyanEquivalent},
-                {ConsoleColor.DarkBlue, darkBlueEquivalent},
-                {ConsoleColor.DarkCyan, darkCyanEquivalent},
-                {ConsoleColor.DarkGray, darkGrayEquivalent},
-                {ConsoleColor.DarkGreen, darkGreenEquivalent},
-                {ConsoleColor.DarkMagenta, darkMagentaEquivalent},
-                {ConsoleColor.DarkRed, darkRedEquivalent},
-                {ConsoleColor.DarkYellow, darkYellowEquivalent},
-                {ConsoleColor.Gray, grayEquivalent},
-                {ConsoleColor.Green, greenEquivalent},
-                {ConsoleColor.Magenta, magentaEquivalent},
-                {ConsoleColor.Red, redEquivalent},
-                {ConsoleColor.White, whiteEquivalent},
-                {ConsoleColor.Yellow, yellowEquivalent}
-            };
+            ConcurrentDictionary<Color, ConsoleColor> colorMap = new ConcurrentDictionary<Color, ConsoleColor>();
+            ConcurrentDictionary<ConsoleColor, Color> consoleColorMap = new ConcurrentDictionary<ConsoleColor, Color>();
+
+            consoleColorMap.TryAdd(ConsoleColor.Black, blackEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Blue, blueEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Cyan, cyanEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkBlue, darkBlueEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkCyan, darkCyanEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkGray, darkGrayEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkGreen, darkGreenEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkMagenta, darkMagentaEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkRed, darkRedEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.DarkYellow, darkYellowEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Gray, grayEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Green, greenEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Magenta, magentaEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Red, redEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.White, whiteEquivalent);
+            consoleColorMap.TryAdd(ConsoleColor.Yellow, yellowEquivalent);
 
             return new ColorStore(colorMap, consoleColorMap);
         }


### PR DESCRIPTION
The normal Dictionary is not thread safe.
With multiple threads we can wind up in the situation where:

Thread A: Check to see if item is in dictionary -> false.
Thread B: Check to see if item is in dictionary -> false,
Thread A: Add item to dictionary -> success,
Thread B: Add item to dictionary -> Item Already Exists, Throw Exception

ConcurrentDictionary provides us with TryAdd which will attempt to add the item to the dictionary but will not throw if the item already exists.

I'm sure you could wrap the .Add in a try catch block if you'd rather go that route but while experimenting with the problem I ended up switching to a ConcurrentDictionary.