### PR TITLE
Fix Colorful.Console.Write Format

### DIFF
--- a/src/Colorful.Console/ColorfulConsoleFront.cs
+++ b/src/Colorful.Console/ColorfulConsoleFront.cs
@@ -553,7 +553,7 @@ namespace Colorful
 
         public static void Write(string format, object arg0)
         {
-            System.Console.WriteLine(format, arg0);
+            System.Console.Write(format, arg0);
         }
 
         public static void Write(string format, object arg0, Color color)


### PR DESCRIPTION
It was calling `System.Console.WriteLine` instead of `System.Console.Write`