### PR TITLE
Figlet.ToAscii() now throws exeption.

### DIFF
--- a/src/Colorful.Console/Figlet.cs
+++ b/src/Colorful.Console/Figlet.cs
@@ -27,6 +27,8 @@
         {
             if (value == null) { throw new ArgumentNullException(nameof(value)); }
 
+            if (Encoding.UTF8.GetByteCount(value) != value.Length) { throw new ArgumentException("String contains non-ascii characters"); }
+
             StringBuilder stringBuilder = new StringBuilder();
 
             int stringWidth = GetStringWidth(font, value);


### PR DESCRIPTION
Figlet.ToAscii() now throws exeption, if argument string contains non-ascii characters. 
http://stackoverflow.com/a/14145356
http://snipplr.com/view/35806/