### PR TITLE
Fixed fast color mapping

### DIFF
--- a/src/Colorful.Console/TaskQueue.cs
+++ b/src/Colorful.Console/TaskQueue.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Colorful
+{
+#if !NET40
+    public class TaskQueue
+    {
+        private readonly SemaphoreSlim _semaphore;
+
+        public TaskQueue()
+        {
+            _semaphore = new SemaphoreSlim(1);
+        }
+
+        public async Task<T> Enqueue<T>(Func<Task<T>> taskGenerator)
+        {
+            await _semaphore.WaitAsync();
+            try
+            {
+                return await taskGenerator();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        public async Task Enqueue(Func<Task> taskGenerator)
+        {
+            await _semaphore.WaitAsync();
+            try
+            {
+                await taskGenerator();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+#endif
+}


### PR DESCRIPTION
Here's what I mean:

### Before
![before](https://user-images.githubusercontent.com/4898202/27111126-5b08dff4-5084-11e7-8a76-2eb722124952.png)

### After
![after](https://user-images.githubusercontent.com/4898202/27111128-5d8d8d74-5084-11e7-8a03-d915608f5169.png)

[Code used in both cases](https://gist.github.com/redbaty/b432253a6402029a1b4396e08e4d9b40)
This is kinda production ready, but I only tested it on .net 4.7 and 4.5, your results may vary. I can test on the weekend if needed.