### PR TITLE
Switched from netcoreapp2.0 to netstandard2.0

### DIFF
--- a/Colorful.Console.sln
+++ b/Colorful.Console.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.13
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{23EF115A-EF43-400D-96AC-DD7219C6ED1D}"
 EndProject
@@ -81,5 +81,8 @@ Global
 		{728892AA-0890-46D9-9365-5F359229230E} = {23EF115A-EF43-400D-96AC-DD7219C6ED1D}
 		{1ADC83F4-BC90-45C8-BAE5-0EE674C0E27B} = {23EF115A-EF43-400D-96AC-DD7219C6ED1D}
 		{E69FFE1E-88DF-47BA-B878-C8D737369DEF} = {23EF115A-EF43-400D-96AC-DD7219C6ED1D}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {633523E8-2BF0-4EBB-A7A7-689D6DD7D166}
 	EndGlobalSection
 EndGlobal

--- a/src/Colorful.Console/ColorManager.cs
+++ b/src/Colorful.Console/ColorManager.cs
@@ -82,13 +82,13 @@ namespace Colorful
 
             try
             {
-#if NETSTANDARD1_3
+#if NETSTANDARD2_0
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
 #endif
                     return GetConsoleColorNative(color);
 
-#if NETSTANDARD1_3
+#if NETSTANDARD2_0
                 }
                 else
                 {
@@ -96,7 +96,7 @@ namespace Colorful
                 }
 #endif
             }
-            // If no NETSTANDARD1_3, but still not running on Windows, catch the exception and approximate the requested color.
+            // If no NETSTANDARD2_0, but still not running on Windows, catch the exception and approximate the requested color.
             catch
             {
                 return color.ToNearestConsoleColor();

--- a/src/Colorful.Console/Colorful.Console.csproj
+++ b/src/Colorful.Console/Colorful.Console.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Colorful.Console</AssemblyTitle>
     <VersionPrefix>1.1</VersionPrefix>
     <Authors>Tom Akita;Muhammad Rehan Saeed;Matt Furden</Authors>
-    <TargetFrameworks>netcoreapp2.0;net40;net45;net451;net452;net46;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40;net45;net451;net452;net46;net461</TargetFrameworks>
     <AssemblyName>Colorful.Console</AssemblyName>
     <PackageId>Colorful.Console</PackageId>
     <PackageTags>Style;Styled;Output;Colourful;Colorful;Console;Command;Line;ASCII;Art;FIGlet</PackageTags>
@@ -25,7 +25,8 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
     <PackageReference Include="System.Collections" Version="4.0.11" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.0.12" />
     <PackageReference Include="System.Console" Version="4.0.0" />

--- a/src/Colorful.Console/ColorfulConsoleFront.cs
+++ b/src/Colorful.Console/ColorfulConsoleFront.cs
@@ -1270,7 +1270,7 @@ namespace Colorful
             return System.Console.OpenStandardError();
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD2_0
         public static Stream OpenStandardError(int bufferSize)
         {
             return System.Console.OpenStandardError(bufferSize);
@@ -1282,7 +1282,7 @@ namespace Colorful
             return System.Console.OpenStandardInput();
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD2_0
         public static Stream OpenStandardInput(int bufferSize)
         {
             return System.Console.OpenStandardInput(bufferSize);
@@ -1294,7 +1294,7 @@ namespace Colorful
             return System.Console.OpenStandardOutput();
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD2_0
         public static Stream OpenStandardOutput(int bufferSize)
         {
             return System.Console.OpenStandardOutput(bufferSize);

--- a/src/ExampleConsoleApplication/ExampleConsoleApplication.csproj
+++ b/src/ExampleConsoleApplication/ExampleConsoleApplication.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Colorful.Console Examples</AssemblyTitle>
     <VersionPrefix>1.1</VersionPrefix>
     <Authors>Tom Akita;Muhammad Rehan Saeed;Matt Furden</Authors>
-    <TargetFrameworks>net40;net45;net451;net452;net46;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net40;net45;net451;net452;net46;net461</TargetFrameworks>
     <AssemblyName>ExampleConsoleApplication</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ExampleConsoleApplication</PackageId>


### PR DESCRIPTION
Switched it to netstandard2.0 as per the recommendation, I've also switched out a few of the compiler conditionals I missed so that they correctly reference `NETSTANDARD2_0` rather than `NETSTANDARD1_3`.

I spotted some kernel32.dll imports in ColorMapper, I'm not sure if they will play nice on anything other than a windows machine, maybe it's branched out somewhere based on a pragma or a conditional I didn't spot.